### PR TITLE
Adds wheels for linux/aarch64

### DIFF
--- a/.github/actions/setup_optimizers_linux/action.yml
+++ b/.github/actions/setup_optimizers_linux/action.yml
@@ -66,7 +66,7 @@ runs:
       env:
         GUROBI_WLS: ${{ inputs.GUROBI_WLS }}
       run: |
-        tar xfz ~/installers/gurobi.tar.gz -C ~/
+        tar xfvz ~/installers/gurobi.tar.gz -C ~/
         # set environment variables
         export GUROBI_HOME="${HOME}/gurobi1100/linux64"
         if [[ ${{ inputs.ARCH }} == "ARM64" ]]; then

--- a/.github/actions/setup_optimizers_linux/action.yml
+++ b/.github/actions/setup_optimizers_linux/action.yml
@@ -44,7 +44,7 @@ runs:
         restore-keys: |
           ${{ runner.os }}-build-${{ env.cache-name }}-
 
-    - if: ${{ steps.cache-installers-linux.outputs.cache-hit != 'true' }} && (inputs.ARCH == 'X64') }}
+    - if: ${{ steps.cache-installers-linux.outputs.cache-hit != 'true' }} && ${{ inputs.ARCH == 'X64' }}
       shell: bash
       name: Download Installers
       run: |
@@ -52,7 +52,7 @@ runs:
         curl -L -o ~/installers/copt.tar.gz https://pub.shanshu.ai/download/copt/7.1.4/linux64/CardinalOptimizer-7.1.4-lnx64.tar.gz
         curl -L -o ~/installers/mosek.tar.bz2 https://download.mosek.com/stable/10.2.0/mosektoolslinux64x86.tar.bz2
 
-    - if: ${{ steps.cache-installers-linux.outputs.cache-hit != 'true' }} && (inputs.ARCH == 'ARM64') }}
+    - if: ${{ steps.cache-installers-linux.outputs.cache-hit != 'true' }} && ${{ inputs.ARCH == 'arm64' }}
       shell: bash
       name: Download Installers
       run: |
@@ -66,7 +66,7 @@ runs:
       env:
         GUROBI_WLS: ${{ inputs.GUROBI_WLS }}
       run: |
-        tar xfvz ~/installers/gurobi.tar.gz -C ~/
+        tar xfz ~/installers/gurobi.tar.gz -C ~/
         # set environment variables
         export GUROBI_HOME="${HOME}/gurobi1100/linux64"
         if [[ ${{ inputs.ARCH }} == "ARM64" ]]; then

--- a/.github/actions/setup_optimizers_linux/action.yml
+++ b/.github/actions/setup_optimizers_linux/action.yml
@@ -16,6 +16,14 @@ inputs:
   CHECK_LICENSE: 
     description: "..."
     required: true
+  ARCH:
+    description: "..."
+    required: true
+    type: choice
+    default: "X64"
+    options:
+      - "X64"
+      - "ARM64"
 
 runs:
   using: "composite"
@@ -36,7 +44,7 @@ runs:
         restore-keys: |
           ${{ runner.os }}-build-${{ env.cache-name }}-
 
-    - if: ${{ steps.cache-installers-linux.outputs.cache-hit != 'true' }}
+    - if: ${{ steps.cache-installers-linux.outputs.cache-hit != 'true' }} && (inputs.ARCH == 'X64') }}
       shell: bash
       name: Download Installers
       run: |
@@ -44,20 +52,32 @@ runs:
         curl -L -o ~/installers/copt.tar.gz https://pub.shanshu.ai/download/copt/7.1.4/linux64/CardinalOptimizer-7.1.4-lnx64.tar.gz
         curl -L -o ~/installers/mosek.tar.bz2 https://download.mosek.com/stable/10.2.0/mosektoolslinux64x86.tar.bz2
 
+    - if: ${{ steps.cache-installers-linux.outputs.cache-hit != 'true' }} && (inputs.ARCH == 'ARM64') }}
+      shell: bash
+      name: Download Installers
+      run: |
+        curl -L -o ~/installers/gurobi.tar.gz https://packages.gurobi.com/11.0/gurobi11.0.3_armlinux64.tar.gz
+        # TODO fix copt link
+        curl -L -o ~/installers/copt.tar.gz https://pub.shanshu.ai/download/copt/7.1.4/linuxarm64/CardinalOptimizer-7.1.4-lnxarm64.tar.gz
+        curl -L -o ~/installers/mosek.tar.bz2 https://download.mosek.com/stable/10.2.3/mosektoolslinuxaarch64.tar.bz2
+
     - name: Setup Gurobi Installation
       shell: bash
       env:
         GUROBI_WLS: ${{ inputs.GUROBI_WLS }}
       run: |
         tar xfz ~/installers/gurobi.tar.gz -C ~/
-        ls ~/gurobi1100/linux64
         # set environment variables
         export GUROBI_HOME="${HOME}/gurobi1100/linux64"
+        if [[ ${{ inputs.ARCH }} == "ARM64" ]]; then
+          export GUROBI_HOME="${HOME}/gurobi1100/armlinux64"
+        fi
+        ls $GUROBI_HOME
         echo "GUROBI_HOME=${GUROBI_HOME}" >> $GITHUB_ENV
         echo "PATH=${PATH}:${GUROBI_HOME}/bin" >> $GITHUB_ENV
         echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GUROBI_HOME}/lib" >> $GITHUB_ENV
         echo $GUROBI_HOME
-        
+
         # setup license using secrets
         echo "$GUROBI_WLS" > ~/gurobi.lic
         echo "GRB_LICENSE_FILE=${HOME}/gurobi.lic" >> $GITHUB_ENV
@@ -99,6 +119,9 @@ runs:
         ls ~/mosek
         # set environment variables
         export MOSEK_10_2_BINDIR="${HOME}/mosek/10.2/tools/platform/linux64x86/bin"
+        if [[ ${{ inputs.ARCH }} == "ARM64" ]]; then
+          export MOSEK_10_2_BINDIR="${HOME}/mosek/10.2/tools/platform/linuxaarch64/bin"
+        fi
         echo "MOSEK_10_2_BINDIR=${MOSEK_10_1_BINDIR}" >> $GITHUB_ENV
         echo "PATH=${PATH}:${MOSEK_10_2_BINDIR}" >> $GITHUB_ENV
         echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${MOSEK_10_2_BINDIR}" >> $GITHUB_ENV

--- a/.github/actions/setup_optimizers_linux/action.yml
+++ b/.github/actions/setup_optimizers_linux/action.yml
@@ -72,11 +72,11 @@ runs:
         if [[ ${{ inputs.ARCH }} == "ARM64" ]]; then
           export GUROBI_HOME="${HOME}/gurobi1100/armlinux64"
         fi
-        ls $GUROBI_HOME
         echo "GUROBI_HOME=${GUROBI_HOME}" >> $GITHUB_ENV
         echo "PATH=${PATH}:${GUROBI_HOME}/bin" >> $GITHUB_ENV
         echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GUROBI_HOME}/lib" >> $GITHUB_ENV
         echo $GUROBI_HOME
+        ls $GUROBI_HOME
 
         # setup license using secrets
         echo "$GUROBI_WLS" > ~/gurobi.lic

--- a/.github/actions/setup_optimizers_linux/action.yml
+++ b/.github/actions/setup_optimizers_linux/action.yml
@@ -44,7 +44,7 @@ runs:
         restore-keys: |
           ${{ runner.os }}-build-${{ env.cache-name }}-
 
-    - if: ${{ steps.cache-installers-linux.outputs.cache-hit != 'true' }} && ${{ inputs.ARCH == 'X64' }}
+    - if: ${{ steps.cache-installers-linux.outputs.cache-hit != 'true' && inputs.ARCH == 'X64' }}
       shell: bash
       name: Download Installers
       run: |
@@ -52,7 +52,7 @@ runs:
         curl -L -o ~/installers/copt.tar.gz https://pub.shanshu.ai/download/copt/7.1.4/linux64/CardinalOptimizer-7.1.4-lnx64.tar.gz
         curl -L -o ~/installers/mosek.tar.bz2 https://download.mosek.com/stable/10.2.0/mosektoolslinux64x86.tar.bz2
 
-    - if: ${{ steps.cache-installers-linux.outputs.cache-hit != 'true' }} && ${{ inputs.ARCH == 'arm64' }}
+    - if: ${{ steps.cache-installers-linux.outputs.cache-hit != 'true' && inputs.ARCH == 'arm64' }}
       shell: bash
       name: Download Installers
       run: |

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -36,12 +36,9 @@ jobs:
         uses: pypa/cibuildwheel@v2.19.2
         env:
           # Select wheels
+          CIBW_BUILD: "*-manylinux_x86_64 *-manylinux_aarch64"
           CIBW_SKIP: "cp36-* cp37-* pp*"
           CIBW_TEST_COMMAND: "python -c \"import pyoptinterface as poi; print(dir(poi))\""
-        with:
-          package-dir: .
-          output-dir: wheelhouse
-          config-file: "{package}/pyproject.toml"
 
       - name: Build wheels (non Linux)
         if: matrix.os != 'ubuntu-latest'

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up QEMU
-        if: matrix.platform == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest'
         uses: docker/setup-qemu-action@v3
         with:
           platforms: all
@@ -38,9 +38,6 @@ jobs:
           # Select wheels
           CIBW_BUILD: "*-manylinux_x86_64 *-manylinux_aarch64"
           CIBW_SKIP: "cp36-* cp37-* pp*"
-          # use manylinux2014
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-          CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
           CIBW_TEST_COMMAND: "python -c \"import pyoptinterface as poi; print(dir(poi))\""
         with:
           package-dir: .
@@ -55,23 +52,6 @@ jobs:
           CIBW_BUILD: "*-win_amd64 *-macosx_x86_64 *-macosx_arm64"
           CIBW_SKIP: "cp36-* cp37-* pp* cp38-macosx_arm64"
           CIBW_ARCHS: "native"
-          CIBW_ENVIRONMENT_MACOS: >
-            MACOSX_DEPLOYMENT_TARGET=10.14
-          CIBW_TEST_COMMAND: "python -c \"import pyoptinterface as poi; print(dir(poi))\""
-        with:
-          package-dir: .
-          output-dir: wheelhouse
-          config-file: "{package}/pyproject.toml"
-
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v2.19.2
-        env:
-          # Select wheels
-          CIBW_BUILD: "*-manylinux_x86_64 *-win_amd64 *-macosx_x86_64 *-macosx_arm64"
-          CIBW_SKIP: "cp36-* cp37-* pp* cp38-macosx_arm64"
-          CIBW_ARCHS: "native"
-          # use manylinux2014
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_ENVIRONMENT_MACOS: >
             MACOSX_DEPLOYMENT_TARGET=10.14
           CIBW_TEST_COMMAND: "python -c \"import pyoptinterface as poi; print(dir(poi))\""

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           platforms: all
 
-      - name: Build wheels (non Linux)
+      - name: Build wheels
         uses: pypa/cibuildwheel@v2.19.2
         env:
           CIBW_ENVIRONMENT_MACOS: >

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -33,9 +33,6 @@ jobs:
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.19.2
-        env:
-          CIBW_ENVIRONMENT_MACOS: >
-            MACOSX_DEPLOYMENT_TARGET=10.14
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -25,6 +25,44 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        if: matrix.platform == 'ubuntu-latest'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+
+      - name: Build wheels (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        uses: pypa/cibuildwheel@v2.19.2
+        env:
+          # Select wheels
+          CIBW_BUILD: "*-manylinux_x86_64 *-manylinux_aarch64"
+          CIBW_SKIP: "cp36-* cp37-* pp*"
+          # use manylinux2014
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+          CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
+          CIBW_TEST_COMMAND: "python -c \"import pyoptinterface as poi; print(dir(poi))\""
+        with:
+          package-dir: .
+          output-dir: wheelhouse
+          config-file: "{package}/pyproject.toml"
+
+      - name: Build wheels (non Linux)
+        if: matrix.os != 'ubuntu-latest'
+        uses: pypa/cibuildwheel@v2.19.2
+        env:
+          # Select wheels
+          CIBW_BUILD: "*-win_amd64 *-macosx_x86_64 *-macosx_arm64"
+          CIBW_SKIP: "cp36-* cp37-* pp* cp38-macosx_arm64"
+          CIBW_ARCHS: "native"
+          CIBW_ENVIRONMENT_MACOS: >
+            MACOSX_DEPLOYMENT_TARGET=10.14
+          CIBW_TEST_COMMAND: "python -c \"import pyoptinterface as poi; print(dir(poi))\""
+        with:
+          package-dir: .
+          output-dir: wheelhouse
+          config-file: "{package}/pyproject.toml"
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.19.2
         env:

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -31,30 +31,11 @@ jobs:
         with:
           platforms: all
 
-      - name: Build wheels (Linux)
-        if: matrix.os == 'ubuntu-latest'
-        uses: pypa/cibuildwheel@v2.19.2
-        env:
-          # Select wheels
-          CIBW_BUILD: "*-manylinux_x86_64 *-manylinux_aarch64"
-          CIBW_SKIP: "cp36-* cp37-* pp*"
-          CIBW_TEST_COMMAND: "python -c \"import pyoptinterface as poi; print(dir(poi))\""
-
       - name: Build wheels (non Linux)
-        if: matrix.os != 'ubuntu-latest'
         uses: pypa/cibuildwheel@v2.19.2
         env:
-          # Select wheels
-          CIBW_BUILD: "*-win_amd64 *-macosx_x86_64 *-macosx_arm64"
-          CIBW_SKIP: "cp36-* cp37-* pp* cp38-macosx_arm64"
-          CIBW_ARCHS: "native"
           CIBW_ENVIRONMENT_MACOS: >
             MACOSX_DEPLOYMENT_TARGET=10.14
-          CIBW_TEST_COMMAND: "python -c \"import pyoptinterface as poi; print(dir(poi))\""
-        with:
-          package-dir: .
-          output-dir: wheelhouse
-          config-file: "{package}/pyproject.toml"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -36,7 +36,6 @@ jobs:
         uses: pypa/cibuildwheel@v2.19.2
         env:
           # Select wheels
-          CIBW_BUILD: "*-manylinux_x86_64 *-manylinux_aarch64"
           CIBW_SKIP: "cp36-* cp37-* pp*"
           CIBW_TEST_COMMAND: "python -c \"import pyoptinterface as poi; print(dir(poi))\""
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,3 +34,13 @@ cmake.build-type = "Release"
 PYTHON_VERSION = { env = "PYTHON_VERSION", default = "3.8" }
 CMAKE_FIND_DEBUG_MODE = "OFF"
 ENABLE_TEST_MAIN = "OFF"
+
+[tool.cibuildwheel]
+test-command = 'python -c "import pyoptinterface as poi; print(dir(poi))"'
+build = "cp3{9,10,11,12}-*"
+skip = "pp* cp38-macosx_arm64"
+archs = "native"
+manylinux-x86_64-image = "quay.io/pypa/manylinux_2_28_x86_64"
+manylinux-aarch64-image = "quay.io/pypa/manylinux_2_28_aarch64"
+[tool.cibuildwheel.linux]
+archs = ["x86_64", "aarch64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,10 +37,10 @@ ENABLE_TEST_MAIN = "OFF"
 
 [tool.cibuildwheel]
 test-command = 'python -c "import pyoptinterface as poi; print(dir(poi))"'
-build = "cp3{9,10,11,12}-*"
-skip = "pp* cp38-macosx_arm64"
+build = "*-manylinux_x86_64 *-manylinux_aarch64 *-win_amd64 *-macosx_x86_64 *-macosx_arm64"
+skip = "cp36-* cp37-* pp* cp38-macosx_arm64"
 archs = "native"
-manylinux-x86_64-image = "quay.io/pypa/manylinux_2_28_x86_64"
-manylinux-aarch64-image = "quay.io/pypa/manylinux_2_28_aarch64"
+manylinux-x86_64-image = "quay.io/pypa/manylinux2014_x86_64"
+manylinux-aarch64-image = "quay.io/pypa/manylinux2014_aarch64"
 [tool.cibuildwheel.linux]
 archs = ["x86_64", "aarch64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,3 +44,5 @@ manylinux-x86_64-image = "quay.io/pypa/manylinux2014_x86_64"
 manylinux-aarch64-image = "quay.io/pypa/manylinux2014_aarch64"
 [tool.cibuildwheel.linux]
 archs = ["x86_64", "aarch64"]
+[tool.cibuildwheel.macos]
+macos-deployment-target = "10.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,4 +45,4 @@ manylinux-aarch64-image = "quay.io/pypa/manylinux2014_aarch64"
 [tool.cibuildwheel.linux]
 archs = ["x86_64", "aarch64"]
 [tool.cibuildwheel.macos]
-macos-deployment-target = "10.14"
+environment = { MACOSX_DEPLOYMENT_TARGET = "10.14" }


### PR DESCRIPTION
# Description

This PR adds wheels for _linux-aarch64_.

## Changes

- Adds `*-manylinux_aarch64` wheels build target(s).
- Moves `cibuildwheel` configuration to `pyproject.toml`.
- Modifies `{...}/setup_optimizers_linux/action.yml` to also download the optimizers for linux-aarch64.

## Notes

- I was not able to add the COPT download link for linux-aarch64, as I don't have access to it.
- I did not add a separate test workflow for linux-aarch64, as no native aarch64/arm64 runner is supported by GitHub yet (for Linux that is). The wheels are built through Qemu, which is already terribly slow. Maybe the missing linux-aarch64 test workflow is an acceptable risk until official release (see [GH blog post](https://github.blog/news-insights/product-news/arm64-on-github-actions-powering-faster-more-efficient-build-systems/#get-started-using-arm-hosted-runners-today)). This also raises the question whether editing the `action.yml` file is necessary at all at this point.
- I moved the build configuration to the project file for more centralized / harmonic builds. Let me know whether you like it.
- I opened another PR for highsbox (see metab0t/highsbox#5)
- I tested the wheels on an RPi and AWS instance for HiGHS and they worked fine.
