### PR TITLE
[GUROBI] Change error message for non-existent constraint

### DIFF
--- a/lib/gurobi_model.cpp
+++ b/lib/gurobi_model.cpp
@@ -1265,7 +1265,7 @@ int GurobiModel::_checked_constraint_index(const ConstraintIndex &constraint)
 	int row = _constraint_index(constraint);
 	if (row < 0)
 	{
-		throw std::runtime_error("Variable does not exist");
+		throw std::runtime_error("Constraint does not exist");
 	}
 	return row;
 }


### PR DESCRIPTION
This pull request fixes an issue where the following code

```python
import pyoptinterface as poi
from pyoptinterface.gurobi import Model

m = Model()
x = m.add_variable()
constr = m.add_linear_constraint(x >= 1)
m.delete_constraint(constr)
m.get_constraint_attribute(constr, poi.ConstraintAttribute.Name)
```

outputs 

`RuntimeError: Variable does not exist`

instead of

`RuntimeError: Constraint does not exist`